### PR TITLE
Replace okHTTP with ion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,12 @@ android {
 }
 
 dependencies {
-  // HTTP Client library from Square. (http://square.github.io/okhttp/)
-  compile 'com.squareup.okhttp:okhttp:2.7.5'
+  // HTTP Client library from Koush. (https://github.com/koush/ion)
+  compile 'com.koushikdutta.ion:ion:2.1.8'
   // Apache utility library for dealing with Collections.
   compile 'org.apache.commons:commons-collections4:4.1'
+  // Android support library.
+  compile 'com.android.support:support-v4:24.1.1'
   // FEST for easier unit testing.
   androidTestCompile 'org.easytesting:fest-assert-core:2.0M10'
 

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/DanbooruLegacyTest.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/DanbooruLegacyTest.java
@@ -17,7 +17,8 @@ public class DanbooruLegacyTest extends SearchClientTestCase {
 
   @Override
   protected SearchClient createSearchClient() {
-    return new DanbooruLegacy("Danbooru", "https://danbooru.donmai.us");
+    return new DanbooruLegacy(getInstrumentation().getContext(),
+        "Danbooru", "https://danbooru.donmai.us");
   }
 
   @Override

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/DanbooruTests.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/DanbooruTests.java
@@ -17,7 +17,8 @@ public class DanbooruTests extends SearchClientTestCase {
 
   @Override
   protected SearchClient createSearchClient() {
-    return new Danbooru("Danbooru", "https://danbooru.donmai.us");
+    return new Danbooru(getInstrumentation().getContext(),
+        "Danbooru", "https://danbooru.donmai.us");
   }
 
   @Override

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/E621Test.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/E621Test.java
@@ -10,7 +10,7 @@ public class E621Test extends SearchClientTestCase{
 
   @Override
   protected SearchClient createSearchClient(){
-    return new E621("E926", "https://e926.net");
+    return new E621(getInstrumentation().getContext(), "E926", "https://e926.net");
   }
 
   @Override

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/GelbooruTest.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/GelbooruTest.java
@@ -16,7 +16,7 @@ public class GelbooruTest extends SearchClientTestCase {
 
   @Override
   protected SearchClient createSearchClient() {
-    return new Gelbooru("Gelbooru", "http://gelbooru.com");
+    return new Gelbooru(getInstrumentation().getContext(), "Gelbooru", "http://gelbooru.com");
   }
 
   @Override

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/MoebooruTest.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/MoebooruTest.java
@@ -14,7 +14,7 @@ public class MoebooruTest extends SearchClientTestCase {
 
   @Override
   protected SearchClient createSearchClient() {
-    return new DanbooruLegacy("yande.re", "https://yande.re");
+    return new DanbooruLegacy(getInstrumentation().getContext(), "yande.re", "https://yande.re");
   }
 
   @Override

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/SearchClientTestCase.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/SearchClientTestCase.java
@@ -7,6 +7,7 @@
 package io.github.tjg1.library.norilib.test;
 
 
+import android.content.Context;
 import android.os.Bundle;
 import android.test.InstrumentationTestCase;
 
@@ -130,7 +131,7 @@ public abstract class SearchClientTestCase extends InstrumentationTestCase {
     settings = bundle.getParcelable("settings");
 
     // Recreate SearchClient from the settings object and test it.
-    client = settings.createSearchClient();
+    client = settings.createSearchClient(getInstrumentation().getContext());
     assertThat(client).isInstanceOf(createSearchClient().getClass());
   }
 

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/ShimmieTests.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/ShimmieTests.java
@@ -16,7 +16,7 @@ public class ShimmieTests extends SearchClientTestCase {
 
   @Override
   protected SearchClient createSearchClient() {
-    return new Shimmie("Dollbooru", "http://dollbooru.org");
+    return new Shimmie(getInstrumentation().getContext(), "Dollbooru", "http://dollbooru.org");
   }
 
   @Override

--- a/src/main/java/io/github/tjg1/library/norilib/clients/E621.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/E621.java
@@ -6,6 +6,7 @@
 
 package io.github.tjg1.library.norilib.clients;
 
+import android.content.Context;
 import android.text.TextUtils;
 
 import org.xml.sax.InputSource;
@@ -35,8 +36,12 @@ public class E621 extends DanbooruLegacy {
   /** Number of images to fetch with each search. */
   private static final int DEFAULT_LIMIT = 100;
 
-  public E621(String name, String endpoint) {
-    super (name, endpoint);
+  public E621(Context context, String name, String endpoint) {
+    super(context, name, endpoint);
+  }
+
+  public E621(Context context, String name, String endpoint, String username, String password) {
+    super(context, name, endpoint, username, password);
   }
 
   @Override

--- a/src/main/java/io/github/tjg1/library/norilib/clients/Gelbooru.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/Gelbooru.java
@@ -6,6 +6,7 @@
 
 package io.github.tjg1.library.norilib.clients;
 
+import android.content.Context;
 import android.net.Uri;
 
 import java.text.ParseException;
@@ -21,12 +22,12 @@ public class Gelbooru extends DanbooruLegacy {
   /** Date format used by Gelbooru. */
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("EEE MMM d HH:mm:ss Z yyyy", Locale.US);
 
-  public Gelbooru(String name, String endpoint) {
-    super(name, endpoint);
+  public Gelbooru(Context context, String name, String endpoint) {
+    super(context, name, endpoint);
   }
 
-  public Gelbooru(String name, String endpoint, String username, String password) {
-    super(name, endpoint, username, password);
+  public Gelbooru(Context context, String name, String endpoint, String username, String password) {
+    super(context, name, endpoint, username, password);
   }
 
   @Override

--- a/src/main/java/io/github/tjg1/library/norilib/clients/SearchClient.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/SearchClient.java
@@ -6,6 +6,7 @@
 
 package io.github.tjg1.library.norilib.clients;
 
+import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -195,18 +196,18 @@ public interface SearchClient {
      *
      * @return A {@link io.github.tjg1.library.norilib.clients.SearchClient} created using settings from this object.
      */
-    public SearchClient createSearchClient() {
+    public SearchClient createSearchClient(Context context) {
       switch (apiType) {
         case DANBOARD:
-          return new Danbooru(name, endpoint, username, password);
+          return new Danbooru(context, name, endpoint, username, password);
         case DANBOARD_LEGACY:
-          return new DanbooruLegacy(name, endpoint, username, password);
+          return new DanbooruLegacy(context, name, endpoint, username, password);
         case SHIMMIE:
-          return new Shimmie(name, endpoint, username, password);
+          return new Shimmie(context, name, endpoint, username, password);
         case GELBOARD:
-          return new Gelbooru(name, endpoint, username, password);
+          return new Gelbooru(context, name, endpoint, username, password);
         case E621:
-          return new E621(name, endpoint);
+          return new E621(context, name, endpoint, username, password);
         default:
           return null;
       }

--- a/src/main/java/io/github/tjg1/library/norilib/clients/Shimmie.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/Shimmie.java
@@ -6,6 +6,8 @@
 
 package io.github.tjg1.library.norilib.clients;
 
+import android.content.Context;
+
 import java.util.Locale;
 
 /**
@@ -13,12 +15,12 @@ import java.util.Locale;
  * Shimmie2 provides an extension that enables a Danbooru 1.x-based API.
  */
 public class Shimmie extends DanbooruLegacy {
-  public Shimmie(String name, String endpoint) {
-    super(name, endpoint);
+  public Shimmie(Context context, String name, String endpoint) {
+    super(context, name, endpoint);
   }
 
-  public Shimmie(String name, String endpoint, String username, String password) {
-    super(name, endpoint, username, password);
+  public Shimmie(Context context, String name, String endpoint, String username, String password) {
+    super(context, name, endpoint, username, password);
   }
 
   @Override


### PR DESCRIPTION
Replaces the okHTTP download library with more modern [ion](https://github.com/koush/ion#download-a-file-with-a-progress-bar). All the tests are passing. 

A side effect is that you now need to pass an Activity Context when creating a SearchClient, but all pending connections get automatically cancelled and cleaned up when the calling Activity closes.