### PR TITLE
Flickr support

### DIFF
--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/FlickrTest.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/FlickrTest.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of nori.
+ * Copyright (c) 2014-2016 Tomasz Jan Góralczyk <tomg@fastmail.uk>
+ * License: GNU GPLv2
+ */
+
+package io.github.tjg1.library.norilib.test;
+
+import io.github.tjg1.library.norilib.clients.Flickr;
+import io.github.tjg1.library.norilib.clients.SearchClient;
+
+/** Tests for the Flickr SearchClient. */
+public class FlickrTest extends SearchClientTestCase {
+  @Override
+  protected SearchClient createSearchClient() {
+    return new Flickr(getInstrumentation().getContext(), "Flickr", Flickr.FLICKR_API_ENDPOINT.toString());
+  }
+
+  /**
+   * @return Tag to search for while testing the support of this API.
+   */
+  @Override
+  protected String getDefaultTag() {
+    return "duck";
+  }
+}

--- a/src/androidTest/java/io/github/tjg1/library/norilib/test/FlickrUserTest.java
+++ b/src/androidTest/java/io/github/tjg1/library/norilib/test/FlickrUserTest.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of nori.
+ * Copyright (c) 2014-2016 Tomasz Jan Góralczyk <tomg@fastmail.uk>
+ * License: GNU GPLv2
+ */
+
+package io.github.tjg1.library.norilib.test;
+
+import io.github.tjg1.library.norilib.clients.FlickrUser;
+import io.github.tjg1.library.norilib.clients.SearchClient;
+
+/** Tests for the FlickrUser SearchClient. */
+public class FlickrUserTest extends SearchClientTestCase {
+  @Override
+  protected SearchClient createSearchClient() {
+    return new FlickrUser(getInstrumentation().getContext(), "me", "https://www.flickr.com/photos/128962151@N05/");
+  }
+
+  /**
+   * @return Tag to search for while testing the support of this API.
+   */
+  @Override
+  protected String getDefaultTag() {
+    return "_";
+  }
+}

--- a/src/main/java/io/github/tjg1/library/norilib/clients/Flickr.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/Flickr.java
@@ -1,0 +1,331 @@
+/*
+ * This file is part of nori.
+ * Copyright (c) 2014-2016 Tomasz Jan Góralczyk <tomg@fastmail.uk>
+ * License: GNU GPLv2
+ */
+
+package io.github.tjg1.library.norilib.clients;
+
+import android.content.Context;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import com.koushikdutta.async.DataEmitter;
+import com.koushikdutta.async.DataSink;
+import com.koushikdutta.async.callback.CompletedCallback;
+import com.koushikdutta.async.future.Future;
+import com.koushikdutta.async.future.FutureCallback;
+import com.koushikdutta.async.future.TransformFuture;
+import com.koushikdutta.async.parser.AsyncParser;
+import com.koushikdutta.async.parser.StringParser;
+import com.koushikdutta.ion.Ion;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import io.github.tjg1.library.norilib.BuildConfig;
+import io.github.tjg1.library.norilib.Image;
+import io.github.tjg1.library.norilib.SearchResult;
+import io.github.tjg1.library.norilib.Tag;
+
+/** Search client for the Flickr API. */
+public class Flickr implements SearchClient {
+  /** Android context. */
+  protected final Context context;
+  /** Human readable service name. */
+  protected final String name;
+  /** API Endpoint. */
+  protected final Uri apiEndpoint;
+  /** Public API key used to access Flickr services. */
+  protected static final String FLICKR_API_KEY = "6b74179518fc00c8bef70b230c7ee880";
+  /** Default API endpoint. */
+  public static final Uri FLICKR_API_ENDPOINT = Uri.parse("https://api.flickr.com/services/rest");
+  /** Number of images to fetch per page. */
+  protected static final int DEFAULT_LIMIT = 100;
+
+  /**
+   * Create a new Flickr API client.
+   *
+   * @param context     Android {@link Context}.
+   * @param name        Human-readable service name. (i.e. Flickr)
+   * @param apiEndpoint API endpoint. (i.e. https://api.flickr.com/services)
+   */
+  public Flickr(Context context, String name, String apiEndpoint) {
+    this.context = context;
+    this.name = name;
+    this.apiEndpoint = apiEndpoint != null ? Uri.parse(apiEndpoint) : FLICKR_API_ENDPOINT;
+  }
+
+  /**
+   * Fetch first page of results containing images with the given set of tags.
+   *
+   * @param tags Search query. A space-separated list of tags.
+   * @return A {@link SearchResult} containing a set of Images.
+   * @throws IOException Network error.
+   */
+  @Override
+  public SearchResult search(String tags) throws IOException {
+    // Return results for page 0.
+    return search(tags, 0);
+  }
+
+  /**
+   * Search for images with the given set of tags.
+   *
+   * @param tags Search query. A space-separated list of tags.
+   * @param pid  Page number. (zero-indexed)
+   * @return A {@link SearchResult} containing a set of Images.
+   * @throws IOException Network error.
+   */
+  @Override
+  public SearchResult search(String tags, int pid) throws IOException {
+    try {
+      return Ion.with(this.context)
+          .load(createSearchURL(tags, pid))
+          .userAgent("nori/" + BuildConfig.VERSION_NAME)
+          .as(new SearchResultParser(tags, pid))
+          .get();
+    } catch (InterruptedException | ExecutionException e) {
+      // Normalise exception to IOException, so method signatures are not tied to a single HTTP
+      // library.
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Asynchronously fetch first page of results containing image with the given set of tags.
+   *
+   * @param tags     Search query. A space-separated list of tags.
+   * @param callback Callback listening for the SearchResult returned in the background.
+   */
+  @Override
+  public void search(String tags, SearchCallback callback) {
+    // Return results for page 0.
+    search(tags, 0, callback);
+  }
+
+  /**
+   * Asynchronously search for images with the given set of tags.
+   *
+   * @param tags     Search query. A space-separated list of tags.
+   * @param pid      Page number. (zero-indexed)
+   * @param callback Callback listening for the SearchResult returned in the background.
+   */
+  @Override
+  public void search(String tags, int pid, final SearchCallback callback) {
+    Ion.with(this.context)
+        .load(createSearchURL(tags, pid))
+        .userAgent("nori/" + BuildConfig.VERSION_NAME)
+        .as(new SearchResultParser(tags, pid))
+        .setCallback(new FutureCallback<SearchResult>() {
+          @Override
+          public void onCompleted(Exception e, SearchResult result) {
+            if (e != null) {
+              callback.onFailure(new IOException(e));
+            } else {
+              callback.onSuccess(result);
+            }
+          }
+        });
+  }
+
+  /**
+   * Get a SafeSearch default query to search for when an app is launched.
+   *
+   * @return Safe-for-work query to search for when an app is launched.
+   */
+  @Override
+  public String getDefaultQuery() {
+    return "";
+  }
+
+  /**
+   * Get a serializable {@link Settings} object with this
+   * {@link SearchClient}'s settings.
+   *
+   * @return A serializable {@link Settings} object.
+   */
+  @Override
+  public Settings getSettings() {
+    return new Settings(Settings.APIType.FLICKR, name, apiEndpoint.toString());
+  }
+
+  /**
+   * Check if the API server requires or supports optional authentication.
+   * <p/>
+   * This is used in the API server settings activity as follows:
+   * If REQUIRED, the user will need to supply valid credentials.
+   * If OPTIONAL, the credential form is shown, but can be left empty.
+   * If NONE, the credential form will not be shown.
+   *
+   * @return {@link AuthenticationType} value for this API backend.
+   */
+  @Override
+  public AuthenticationType requiresAuthentication() {
+    return AuthenticationType.NONE;
+  }
+
+  /**
+   * Parse an XML response returned by the API.
+   *
+   * @param body   HTTP Response body.
+   * @param tags   Tags used to retrieve the response.
+   * @param offset Current paging offset.
+   * @return A {@link io.github.tjg1.library.norilib.SearchResult} parsed from given XML.
+   */
+  protected SearchResult parseXMLResponse(String body, String tags, int offset) throws IOException {
+    final List<Image> imageList = new ArrayList<>(DEFAULT_LIMIT);
+
+    try {
+      Document doc = DocumentBuilderFactory
+          .newInstance()
+          .newDocumentBuilder()
+          .parse(new InputSource(new StringReader(body)));
+
+      NodeList nodeList = doc.getElementsByTagName("photo");
+
+      for (int i = 0; i < nodeList.getLength(); i++) {
+        Node node = nodeList.item(i);
+
+        if (node.getNodeType() == Node.ELEMENT_NODE) {
+          Element element = (Element) node;
+
+          final Image image = new Image();
+          image.searchPage = offset;
+          image.searchPagePosition = i;
+
+          String urlQ = element.getAttribute("url_q");
+          String urlM = element.getAttribute("url_m");
+          String urlL = element.getAttribute("url_l");
+          String urlO = element.getAttribute("url_o");
+
+          // Set file url.
+          if (!TextUtils.isEmpty(urlO)) {
+            image.fileUrl = urlO;
+            image.width = Integer.parseInt(element.getAttribute("width_o"));
+            image.height = Integer.parseInt(element.getAttribute("height_o"));
+          } else if (!TextUtils.isEmpty(urlL)) {
+            image.fileUrl = urlL;
+            image.width = Integer.parseInt(element.getAttribute("width_l"));
+            image.height = Integer.parseInt(element.getAttribute("height_l"));
+          } else if (!TextUtils.isEmpty(urlM)) {
+            image.fileUrl = urlM;
+            image.width = Integer.parseInt(element.getAttribute("width_m"));
+            image.height = Integer.parseInt(element.getAttribute("height_m"));
+          }
+
+          // Set sample url.
+          if (!TextUtils.isEmpty(urlL)) {
+            image.sampleUrl = urlL;
+            image.sampleWidth = Integer.parseInt(element.getAttribute("width_l"));
+            image.sampleHeight = Integer.parseInt(element.getAttribute("height_l"));
+          } else if (!TextUtils.isEmpty(urlM)) {
+            image.sampleUrl = urlM;
+            image.sampleWidth = Integer.parseInt(element.getAttribute("width_m"));
+            image.sampleHeight = Integer.parseInt(element.getAttribute("height_m"));
+          }
+
+          // Set preview url.
+          if (!TextUtils.isEmpty(urlQ)) {
+            image.previewUrl = urlQ;
+            image.previewWidth = Integer.parseInt(element.getAttribute("width_q"));
+            image.previewHeight = Integer.parseInt(element.getAttribute("height_q"));
+          }
+
+          image.tags = Tag.arrayFromString(element.getAttribute("tags"));
+          image.id = element.getAttribute("id");
+          image.webUrl = webUrlFromId(element.getAttribute("owner"), element.getAttribute("id"));
+          image.parentId = null;
+          image.safeSearchRating = Image.SafeSearchRating.S;
+          image.score = 0;
+          image.md5 = "2d57d21f35e060a4c5e81c03aea3efa8"; // not implemented
+          image.createdAt = new Date(Long.parseLong(element.getAttribute("dateupload"), 10) * 1000);
+
+          imageList.add(image);
+        }
+      }
+
+    } catch (SAXException | ParserConfigurationException e) {
+      throw new IOException(e);
+    }
+
+    return new SearchResult(imageList.toArray(new Image[imageList.size()]), Tag.arrayFromString(tags), offset);
+  }
+
+
+  /** Create Flickr web url for given user and photo id. */
+  protected String webUrlFromId(String userId, String photoId) {
+    return "https://www.flickr.com/photos/" + userId + "/" + photoId;
+  }
+
+  /**
+   * Generate request URL to the search API endpoint.
+   *
+   * @param tags Space-separated tags.
+   * @param pid  Page number (0-indexed).
+   * @return URL to search results API.
+   */
+  protected String createSearchURL(String tags, int pid) {
+    return new Uri.Builder()
+        .scheme(apiEndpoint.getScheme())
+        .authority(apiEndpoint.getAuthority())
+        .path(apiEndpoint.getPath())
+        .appendQueryParameter("api_key", FLICKR_API_KEY)
+        .appendQueryParameter("method", !TextUtils.isEmpty(tags) ? "flickr.photos.search" : "flickr.photos.getRecent")
+        .appendQueryParameter("text", tags != null ? tags : "")
+        .appendQueryParameter("per_page", Integer.toString(DEFAULT_LIMIT, 10))
+        .appendQueryParameter("extras", "date_upload,owner_name,media,tags,path_alias,icon_server,o_dims,path_alias,original_format,url_q,url_m,url_l,url_o")
+        .appendQueryParameter("page", Integer.toString(pid + 1, 10))
+        .build()
+        .toString();
+  }
+
+  /** Asynchronous search parser to use with ion. */
+  protected class SearchResultParser implements AsyncParser<SearchResult> {
+    /** Tags searched for. */
+    private final String tags;
+    /** Current page offset. */
+    private final int pageOffset;
+
+    public SearchResultParser(String tags, int pageOffset) {
+      this.tags = tags;
+      this.pageOffset = pageOffset;
+    }
+
+    @Override
+    public Future<SearchResult> parse(DataEmitter emitter) {
+      return new StringParser().parse(emitter)
+          .then(new TransformFuture<SearchResult, String>() {
+            @Override
+            protected void transform(String result) throws Exception {
+              setComplete(parseXMLResponse(result, tags, pageOffset));
+            }
+          });
+    }
+
+    @Override
+    public void write(DataSink sink, SearchResult value, CompletedCallback completed) {
+      // Not implemented.
+    }
+
+    @Override
+    public Type getType() {
+      return null;
+    }
+  }
+}

--- a/src/main/java/io/github/tjg1/library/norilib/clients/FlickrUser.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/FlickrUser.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of nori.
+ * Copyright (c) 2014-2016 Tomasz Jan Góralczyk <tomg@fastmail.uk>
+ * License: GNU GPLv2
+ */
+
+package io.github.tjg1.library.norilib.clients;
+
+import android.content.Context;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Flickr SearchClient limited to searching for images from a single user. */
+public class FlickrUser extends Flickr {
+  /** Regex pattern used to match Flickr user URLs. */
+  public static final String FLICKR_USER_REGEX = "https?:\\/\\/(?:www\\.)?flickr\\.com\\/photos\\/(.+?)\\/?$";
+
+  /**
+   * Create a new Flickr API client.
+   *
+   * @param context     Android {@link Context}.
+   * @param name        Human-readable service name. (i.e. Flickr)
+   * @param apiEndpoint API endpoint. (i.e. https://api.flickr.com/services)
+   */
+  public FlickrUser(Context context, String name, String apiEndpoint) {
+    super(context, name, apiEndpoint);
+  }
+
+  @Override
+  public Settings getSettings() {
+    return new Settings(Settings.APIType.FLICKR_USER, name, apiEndpoint.toString());
+  }
+
+  /**
+   * Generate request URL to the search API endpoint.
+   *
+   * @param tags Space-separated tags.
+   * @param pid  Page number (0-indexed).
+   * @return URL to search results API.
+   */
+  protected String createSearchURL(String tags, int pid) {
+    Pattern p = Pattern.compile(FLICKR_USER_REGEX);
+    Matcher m = p.matcher(apiEndpoint.toString());
+
+    if (m.matches()) {
+      return new Uri.Builder()
+          .scheme(FLICKR_API_ENDPOINT.getScheme())
+          .authority(FLICKR_API_ENDPOINT.getAuthority())
+          .path(FLICKR_API_ENDPOINT.getPath())
+          .appendQueryParameter("api_key", FLICKR_API_KEY)
+          .appendQueryParameter("user_id", m.group(1))
+          .appendQueryParameter("method", !TextUtils.isEmpty(tags) ? "flickr.photos.search" : "flickr.people.getPhotos")
+          .appendQueryParameter("text", tags != null ? tags : "")
+          .appendQueryParameter("per_page", Integer.toString(DEFAULT_LIMIT, 10))
+          .appendQueryParameter("extras", "date_upload,owner_name,media,tags,path_alias,icon_server,o_dims,path_alias,original_format,url_q,url_m,url_l,url_o")
+          .appendQueryParameter("page", Integer.toString(pid + 1, 10))
+          .build()
+          .toString();
+    }
+    return super.createSearchURL(tags, pid);
+  }
+}

--- a/src/main/java/io/github/tjg1/library/norilib/clients/SearchClient.java
+++ b/src/main/java/io/github/tjg1/library/norilib/clients/SearchClient.java
@@ -208,6 +208,10 @@ public interface SearchClient {
           return new Gelbooru(context, name, endpoint, username, password);
         case E621:
           return new E621(context, name, endpoint, username, password);
+        case FLICKR:
+          return new Flickr(context, name, endpoint);
+        case FLICKR_USER:
+          return new FlickrUser(context, name, endpoint);
         default:
           return null;
       }
@@ -238,7 +242,9 @@ public interface SearchClient {
       DANBOARD_LEGACY,
       GELBOARD,
       SHIMMIE,
-      E621
+      E621,
+      FLICKR,
+      FLICKR_USER
     }
   }
 

--- a/src/main/java/io/github/tjg1/library/norilib/service/ServiceTypeDetectionService.java
+++ b/src/main/java/io/github/tjg1/library/norilib/service/ServiceTypeDetectionService.java
@@ -16,6 +16,8 @@ import com.koushikdutta.ion.Ion;
 import com.koushikdutta.ion.Response;
 
 import io.github.tjg1.library.norilib.BuildConfig;
+import io.github.tjg1.library.norilib.clients.Flickr;
+import io.github.tjg1.library.norilib.clients.FlickrUser;
 import io.github.tjg1.library.norilib.clients.SearchClient;
 import io.github.tjg1.library.norilib.util.HashUtils;
 
@@ -101,6 +103,21 @@ public class ServiceTypeDetectionService extends IntentService {
       broadcastIntent.putExtra(ENDPOINT_URL, "https://" + uri.getHost());
       broadcastIntent.putExtra(API_TYPE, SearchClient.Settings.APIType.E621.ordinal());
       sendBroadcast((broadcastIntent));
+      return;
+    }
+
+    // api.flickr.com
+    if ("d9fe439308fd55bbfbc6ae351fc084f04fd64f96b6102bdb6edbc7edcc44889aa3a471469ca5ab529857ffaa3013c691c36812e0a1698257334efb4e9af358ea".equals(HashUtils.sha512(uri.getHost(),"nori"))) {
+      broadcastIntent.putExtra(RESULT_CODE, RESULT_OK);
+      broadcastIntent.putExtra(ENDPOINT_URL, Flickr.FLICKR_API_ENDPOINT.toString());
+      broadcastIntent.putExtra(API_TYPE, SearchClient.Settings.APIType.FLICKR.ordinal());
+      sendBroadcast(broadcastIntent);
+      return;
+    } else if (uri.toString().matches(FlickrUser.FLICKR_USER_REGEX)) {
+      broadcastIntent.putExtra(RESULT_CODE, RESULT_OK);
+      broadcastIntent.putExtra(ENDPOINT_URL, "https://" + uri.getHost() + uri.getPath());
+      broadcastIntent.putExtra(API_TYPE, SearchClient.Settings.APIType.FLICKR_USER.ordinal());
+      sendBroadcast(broadcastIntent);
       return;
     }
 


### PR DESCRIPTION
This adds Flickr support for either searching the whole site or images from a single user.

To test
- Searching the whole site: Add a service in Nori with the URL: https://api.flickr.com/
- Searching photos from a single user: Add a service in Nori with the URL to the user's profile, i.e. https://www.flickr.com/photos/121010101@N05/